### PR TITLE
Simplify GitHub Actions release workflows to not use custom action

### DIFF
--- a/.github/workflows/release-major-workflow.yaml
+++ b/.github/workflows/release-major-workflow.yaml
@@ -1,0 +1,13 @@
+---
+name: Release Major
+on: [workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: cliffano/release-action@v2.0.0
+        with:
+          release_type: major
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/.github/workflows/release-minor-workflow.yaml
+++ b/.github/workflows/release-minor-workflow.yaml
@@ -1,0 +1,13 @@
+---
+name: Release Minor
+on: [workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: cliffano/release-action@v2.0.0
+        with:
+          release_type: minor
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/.github/workflows/release-patch-workflow.yaml
+++ b/.github/workflows/release-patch-workflow.yaml
@@ -1,0 +1,13 @@
+---
+name: Release Patch
+on: [workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: cliffano/release-action@v2.0.0
+        with:
+          release_type: patch
+          github_token: ${{ secrets.SHINEWORKS_GITHUB_TOKEN }}
+          git_user_email: shinesworks@shinesolutions.com
+          git_user_name: Shine Works

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new application property parameter `aem_client_api_verifyssl`
 
 ### Changed
+- Simplify GitHub Actions release workflows to not use custom action
 - Replace Maven Central base URL from http://central.maven.org to https://repo.maven.apache.org
 
 ## [1.4.1] - 2019-05-19


### PR DESCRIPTION
## Summary
- Simplify GitHub Actions release workflows to not use custom action

Part of RS-204: uplift release workflows to the shared the-works-buildenv pattern.

## Test plan
- [ ] Confirm release-major/minor/patch workflows run correctly via workflow_dispatch after merge
